### PR TITLE
Add Status entry initialization in binding and instance controller

### DIFF
--- a/pkg/controller/controller_binding.go
+++ b/pkg/controller/controller_binding.go
@@ -20,21 +20,22 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-
-	osb "github.com/pmorie/go-open-service-broker-client/v2"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog"
+	"reflect"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
 	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
+
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/klog"
 )
 
 const (
@@ -176,6 +177,15 @@ func (c *controller) reconcileServiceBinding(binding *v1beta1.ServiceBinding) er
 // service bindings.
 func (c *controller) reconcileServiceBindingAdd(binding *v1beta1.ServiceBinding) error {
 	pcb := pretty.NewBindingContextBuilder(binding)
+
+	if !c.isServiceBindingStatusInitialized(binding) {
+		klog.V(4).Info(pcb.Message("Initialize Status entry"))
+		if err := c.initializeServiceBindingStatus(binding); err != nil {
+			klog.Errorf(pcb.Messagef("Error initializing status: %v", err))
+			return err
+		}
+		return nil
+	}
 
 	if isServiceBindingFailed(binding) {
 		klog.V(4).Info(pcb.Message("not processing event; status showed that it has failed"))
@@ -761,6 +771,34 @@ func (c *controller) updateServiceBindingCondition(
 		))
 	}
 	return err
+}
+
+func (c *controller) isServiceBindingStatusInitialized(binding *v1beta1.ServiceBinding) bool {
+	emptyStatus := v1beta1.ServiceBindingStatus{}
+	if reflect.DeepEqual(binding.Status, emptyStatus) {
+		return false
+	}
+
+	return true
+}
+
+// initializeServiceBindingStatus initialize the ServiceBindingStatus.
+// In normal scenario it should be done when client is creating the ServiceBinding,
+// but right now we cannot modify the Status (sub-resource) in webhook on CREATE action.
+// As a temporary solution we are doing that in the reconcile function.
+func (c *controller) initializeServiceBindingStatus(binding *v1beta1.ServiceBinding) error {
+	updated := binding.DeepCopy()
+	updated.Status = v1beta1.ServiceBindingStatus{
+		Conditions:   []v1beta1.ServiceBindingCondition{},
+		UnbindStatus: v1beta1.ServiceBindingUnbindStatusNotRequired,
+	}
+
+	_, err := c.serviceCatalogClient.ServiceBindings(updated.Namespace).UpdateStatus(updated)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // recordStartOfServiceBindingOperation updates the binding to indicate

--- a/pkg/controller/controller_instance.go
+++ b/pkg/controller/controller_instance.go
@@ -20,27 +20,27 @@ import (
 	stderrors "errors"
 	"fmt"
 	"net/url"
+	"reflect"
 	"sync"
 	"time"
 
-	osb "github.com/pmorie/go-open-service-broker-client/v2"
-	"k8s.io/klog"
+	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
+	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
 
+	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-
-	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
-	scfeatures "github.com/kubernetes-incubator/service-catalog/pkg/features"
-	"github.com/kubernetes-incubator/service-catalog/pkg/pretty"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
 )
 
 const (
@@ -503,6 +503,15 @@ func (c *controller) removeInstanceFromRetryMap(instance *v1beta1.ServiceInstanc
 // of new service instances.
 func (c *controller) reconcileServiceInstanceAdd(instance *v1beta1.ServiceInstance) error {
 	pcb := pretty.NewInstanceContextBuilder(instance)
+
+	if !c.isServiceInstanceStatusInitialized(instance) {
+		klog.V(4).Info(pcb.Message("Initialize Status entry"))
+		if err := c.initializeServiceInstanceStatus(instance); err != nil {
+			klog.Errorf(pcb.Messagef("Error initializing status: %v", err))
+			return err
+		}
+		return nil
+	}
 
 	if isServiceInstanceProcessedAlready(instance) {
 		klog.V(4).Info(pcb.Message("Not processing event because status showed there is no work to do"))
@@ -1931,6 +1940,34 @@ func (c *controller) updateServiceInstanceCondition(
 	}
 
 	return updatedInstance, err
+}
+
+func (c *controller) isServiceInstanceStatusInitialized(instance *v1beta1.ServiceInstance) bool {
+	emptyStatus := v1beta1.ServiceInstanceStatus{}
+	if reflect.DeepEqual(instance.Status, emptyStatus) {
+		return false
+	}
+
+	return true
+}
+
+// initializeServiceInstanceStatus initialize the ServiceInstanceStatus.
+// In normal scenario it should be done when client is creating the ServiceInstance,
+// but right now we cannot modify the Status (sub-resource) in webhook on CREATE action.
+// As a temporary solution we are doing that in the reconcile function.
+func (c *controller) initializeServiceInstanceStatus(instance *v1beta1.ServiceInstance) error {
+	updated := instance.DeepCopy()
+	updated.Status = v1beta1.ServiceInstanceStatus{
+		Conditions:        []v1beta1.ServiceInstanceCondition{},
+		DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
+	}
+
+	_, err := c.serviceCatalogClient.ServiceInstances(updated.Namespace).UpdateStatus(updated)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // prepareObservedGeneration sets the instance's observed generation

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -875,6 +875,10 @@ func getTestServiceInstanceK8SNames() *v1beta1.ServiceInstance {
 			},
 			ExternalID: testServiceInstanceGUID,
 		},
+		Status: v1beta1.ServiceInstanceStatus{
+			Conditions: []v1beta1.ServiceInstanceCondition{},
+			DeprovisionStatus: v1beta1.ServiceInstanceDeprovisionStatusNotRequired,
+		},
 	}
 }
 

--- a/pkg/webhook/servicecatalog/servicebinding/mutation/handler.go
+++ b/pkg/webhook/servicecatalog/servicebinding/mutation/handler.go
@@ -97,12 +97,6 @@ func (h *CreateUpdateHandler) mutateOnCreate(ctx context.Context, req admission.
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
 		setServiceBindingUserInfo(req, binding)
 	}
-
-	// TODO: cannot be modified on webhook side, need to moved directly to controller
-	//binding.Status = sc.ServiceBindingStatus{
-	//	Conditions: []sc.ServiceBindingCondition{},
-	//	UnbindStatus: sc.ServiceBindingUnbindStatusNotRequired,
-	//}
 }
 
 func (h *CreateUpdateHandler) mutateOnUpdate(ctx context.Context, obj *sc.ServiceBinding) {

--- a/pkg/webhook/servicecatalog/serviceinstance/mutation/handler.go
+++ b/pkg/webhook/servicecatalog/serviceinstance/mutation/handler.go
@@ -93,12 +93,6 @@ func (h *CreateUpdateHandler) mutateOnCreate(ctx context.Context, req admission.
 	if utilfeature.DefaultFeatureGate.Enabled(scfeatures.OriginatingIdentity) {
 		setServiceInstanceUserInfo(req, instance)
 	}
-
-	// TODO: cannot be modified on webhook side, need to moved directly to controller
-	//instance.Status = sc.ServiceInstanceStatus{
-	//	Conditions:        []sc.ServiceInstanceCondition{},
-	//	DeprovisionStatus: sc.ServiceInstanceDeprovisionStatusNotRequired,
-	//}
 }
 
 func (h *CreateUpdateHandler) mutateOnUpdate(ctx context.Context, obj *sc.ServiceInstance) {


### PR DESCRIPTION
This PR is a 
 - [x] Feature Implementation
 - [ ] Bug Fix
 - [ ] Documentation

**What this PR does / why we need it**:

Previously the status entry was initialized in api-server in [PrepareForCreate](https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/registry/servicecatalog/instance/strategy.go#L125-L129) function. Right now we cannot do that in webhook handler, so as a temporary workaround we need to move this logic to the controller reconcile function.

**Which issue(s) this PR fixes** 

- https://github.com/kyma-project/kyma/issues/2784


Final merge blocked by: https://github.com/kyma-incubator/service-catalog/pull/7/files