### PR TITLE
Move creating PVC functionality to migration tool

### DIFF
--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -34,6 +34,9 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs:     ["get", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs:     ["get", "delete"]
   - apiGroups: ["servicecatalog.k8s.io"]
     resources:
     - "clusterserviceclasses"
@@ -130,6 +133,8 @@ spec:
           - {{ template "fullname" . }}-webhook
           - --webhook-service-port
           - "{{ .Values.webhook.service.port }}"
+          - --pvc-name
+          - {{ template "fullname" . }}-migration-storage
           volumeMounts:
           - name: storage
             mountPath: /data

--- a/charts/catalog/templates/migration-job.yaml
+++ b/charts/catalog/templates/migration-job.yaml
@@ -36,7 +36,7 @@ rules:
     verbs:     ["get", "update"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs:     ["get", "delete"]
+    verbs:     ["delete"]
   - apiGroups: ["servicecatalog.k8s.io"]
     resources:
     - "clusterserviceclasses"

--- a/charts/catalog/templates/pre-migration-job.yaml
+++ b/charts/catalog/templates/pre-migration-job.yaml
@@ -73,7 +73,6 @@ roleRef:
   name: pre-migration-job-account
 
 ---
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/cmd/migration/migration.go
+++ b/cmd/migration/migration.go
@@ -138,7 +138,7 @@ func RunCommand(opt *Options) error {
 			return err
 		}
 
-		err = svc.DeletePersistentVolumeClaim(opt.PersistentVolumeClaimName)
+		err = svc.AssertPersistentVolumeClaimDeleted(opt.PersistentVolumeClaimName)
 		if err != nil {
 			return err
 		}

--- a/cmd/migration/migration.go
+++ b/cmd/migration/migration.go
@@ -137,6 +137,11 @@ func RunCommand(opt *Options) error {
 		if err != nil {
 			return err
 		}
+
+		err = svc.DeletePersistentVolumeClaim(opt.PersistentVolumeClaimName)
+		if err != nil {
+			return err
+		}
 	case deployBlockerActionName:
 		return svc.EnableBlocker(blockerBaseName)
 	case undeployBlockerActionName:

--- a/cmd/migration/options.go
+++ b/cmd/migration/options.go
@@ -33,17 +33,19 @@ const (
 	serviceCatalogNamespaceParameter = "service-catalog-namespace"
 	webhookServiceNameParameter      = "webhook-service-name"
 	webhookServicePortParameter      = "webhook-service-port"
+	pvcNameParameter                 = "pvc-name"
 )
 
 // Options holds configuration for the migration job
 type Options struct {
-	Action                string
-	StoragePath           string
-	ReleaseNamespace      string
-	ControllerManagerName string
-	ApiserverName         string
-	WebhookServiceName    string
-	WebhookServicePort    string
+	Action                    string
+	StoragePath               string
+	ReleaseNamespace          string
+	ControllerManagerName     string
+	ApiserverName             string
+	WebhookServiceName        string
+	WebhookServicePort        string
+	PersistentVolumeClaimName string
 }
 
 // NewMigrationOptions creates and returns a new Options
@@ -60,25 +62,47 @@ func (c *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.ApiserverName, apiserverNameParameter, "", "Name of apiserver deployment")
 	fs.StringVar(&c.WebhookServiceName, webhookServiceNameParameter, "", "Name of webhook service")
 	fs.StringVar(&c.WebhookServicePort, webhookServicePortParameter, "", "Port of the webhook service")
+	fs.StringVar(&c.PersistentVolumeClaimName, pvcNameParameter, "", "Name of PersistentVolumeClaim in which resources will be stored")
 }
 
 // Validate checks flag has been set and has a proper value
 func (c *Options) Validate() error {
 	switch c.Action {
-	case backupActionName, restoreActionName:
+	case backupActionName:
+		if err := c.requiredParamaters(map[string]string{
+			serviceCatalogNamespaceParameter: c.ReleaseNamespace,
+			controllerManagerNameParameter:   c.ControllerManagerName,
+			apiserverNameParameter:           c.ApiserverName,
+			storagePathParameter:             c.StoragePath,
+		}); err != nil {
+			return err
+		}
+	case restoreActionName:
+		if err := c.requiredParamaters(map[string]string{
+			serviceCatalogNamespaceParameter: c.ReleaseNamespace,
+			controllerManagerNameParameter:   c.ControllerManagerName,
+			webhookServiceNameParameter:      c.WebhookServiceName,
+			webhookServicePortParameter:      c.WebhookServicePort,
+			storagePathParameter:             c.StoragePath,
+			pvcNameParameter:                 c.PersistentVolumeClaimName,
+		}); err != nil {
+			return err
+		}
 	case deployBlockerActionName, undeployBlockerActionName:
 		return nil
 	default:
 		return fmt.Errorf("action must be 'restore', 'backup', 'deploy-blocker' or 'undeploy-blocker', you provided %s", c.Action)
 	}
-	if c.StoragePath == "" {
-		return fmt.Errorf("%s must not be empty", storagePathParameter)
+
+	return nil
+}
+
+func (c *Options) requiredParamaters(parameters map[string]string) error {
+	for name, value := range parameters {
+		if value == "" {
+			return fmt.Errorf("%s must not be empty", name)
+		}
 	}
-	if c.ReleaseNamespace == "" {
-		return fmt.Errorf("%s must not be empty", serviceCatalogNamespaceParameter)
-	}
-	if c.ControllerManagerName == "" {
-		return fmt.Errorf("%s must not be empty", controllerManagerNameParameter)
-	}
+
 	return nil
 }

--- a/pkg/migration/volume.go
+++ b/pkg/migration/volume.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/klog"
 )
 
-// DeletePersistentVolumeClaim deletes PVC resource in which backup data will be kept and make sure it was removed
-func (m *Service) DeletePersistentVolumeClaim(name string) error {
+// AssertPersistentVolumeClaimDeleted deletes PVC resource in which backup data will be kept and make sure it was removed
+func (m *Service) AssertPersistentVolumeClaimDeleted(name string) error {
 	klog.Info("Deleting PersistentVolumeClaim")
 	err := m.coreInterface.PersistentVolumeClaims(m.releaseNamespace).Delete(name, &metav1.DeleteOptions{})
 	if apiErr.IsNotFound(err) {

--- a/pkg/migration/volume.go
+++ b/pkg/migration/volume.go
@@ -29,7 +29,7 @@ func (m *Service) DeletePersistentVolumeClaim(name string) error {
 	err := m.coreInterface.PersistentVolumeClaims(m.releaseNamespace).Delete(name, &metav1.DeleteOptions{})
 	if apiErr.IsNotFound(err) {
 		klog.Info("PersistentVolumeClaim was removed")
-		return err
+		return nil
 	}
 	if err != nil {
 		return errors.Wrap(err, "while deleting PersistentVolumeClaim")

--- a/pkg/migration/volume.go
+++ b/pkg/migration/volume.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"github.com/pkg/errors"
+	apiErr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+// DeletePersistentVolumeClaim deletes PVC resource in which backup data will be kept and make sure it was removed
+func (m *Service) DeletePersistentVolumeClaim(name string) error {
+	klog.Info("Deleting PersistentVolumeClaim")
+	err := m.coreInterface.PersistentVolumeClaims(m.releaseNamespace).Delete(name, &metav1.DeleteOptions{})
+	if apiErr.IsNotFound(err) {
+		klog.Info("PersistentVolumeClaim was removed")
+		return err
+	}
+	if err != nil {
+		return errors.Wrap(err, "while deleting PersistentVolumeClaim")
+	}
+
+	// PVC will be removed after erase "kubernetes.io/pvc-protection" finalizer
+	// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storage-object-in-use-protection
+	return nil
+}

--- a/test/upgrade/scripts/minikube.sh
+++ b/test/upgrade/scripts/minikube.sh
@@ -50,7 +50,7 @@ function waitForMinikubeToBeUp() {
 function checkMinikubeStatus() {
     MINIKUBE_STATUS="$(minikube status --format {{.Host}})"
     KUBELET_STATUS="$(minikube status --format {{.Kubelet}})"
-    APISERVER_STATUS="$(minikube status --format {{.ApiServer}})"
+    APISERVER_STATUS="$(minikube status --format {{.APIServer}})"
 
     if [[ "$MINIKUBE_STATUS" == "Running" ]] &&
        [[ "$KUBELET_STATUS" == "Running" ]] &&


### PR DESCRIPTION
Removing PVC with restored data after complete migration. Related [#4740](https://github.com/kyma-project/kyma/issues/4740)

PVC is not removed from the chart because `pre-migration/migration` job required existing pvc to mount before the job will be created. 